### PR TITLE
Fix bug with string handling in schema generation

### DIFF
--- a/drupal_schema_grt.py
+++ b/drupal_schema_grt.py
@@ -254,12 +254,12 @@ def generateFieldDefinition(column, comment_replace) :
  
   # Description.
   if column.comment :
-    comment = ' ' + column.comment + ' '
+    comment = ' ' + column.comment.replace("'", "\\'") + ' '
      
     for key, value in comment_replace.iteritems() :
       comment = comment.replace(key, value)
    
-    specs.append("'description' => '%s'" % comment.strip().replace("'", "\\'"))
+    specs.append("'description' => '%s'" % comment.strip())
    
   # Create the field defenition array.
   definition = "      '%s' => array(\n" % column.name

--- a/drupal_schema_grt.py
+++ b/drupal_schema_grt.py
@@ -250,7 +250,7 @@ def generateFieldDefinition(column, comment_replace) :
     elif column.defaultValue == 'NULL' and not column.isNotNull :
       specs.append("'default' => NULL")
     else :
-      specs.append("'default' => '%s'" % column.defaultValue.replace("'", "\'"))
+      specs.append("'default' => '%s'" % column.defaultValue.strip("'").replace("'", "\\'"))
  
   # Description.
   if column.comment :
@@ -259,7 +259,7 @@ def generateFieldDefinition(column, comment_replace) :
     for key, value in comment_replace.iteritems() :
       comment = comment.replace(key, value)
    
-    specs.append("'description' => '%s'" % comment.strip())
+    specs.append("'description' => '%s'" % comment.strip().replace("'", "\\'"))
    
   # Create the field defenition array.
   definition = "      '%s' => array(\n" % column.name

--- a/drupal_schema_grt.py
+++ b/drupal_schema_grt.py
@@ -111,7 +111,7 @@ def generateTableDefinition(table, comment_replace):
    
   # Table description.
   if table.comment:
-    definition += "    'description' => '%s',\n" % table.comment.replace("'", "\'").strip()
+    definition += "    'description' => '%s',\n" % table.comment.replace("'", "\\'").strip()
      
   # Add all columns.
   definition += "    'fields' => array(\n"
@@ -254,7 +254,7 @@ def generateFieldDefinition(column, comment_replace) :
  
   # Description.
   if column.comment :
-    comment = ' ' + column.comment.replace("'", "\'") + ' '
+    comment = ' ' + column.comment + ' '
      
     for key, value in comment_replace.iteritems() :
       comment = comment.replace(key, value)


### PR DESCRIPTION
Hey, cool plugin! This has been an important part of my workflow with a legacy D7 application for a while. After finally getting tired of manually correcting the output every time, I figured I'd just fix the bugs and submit a PR.

The scripts now properly handles:
- Cases where default value of a column is set to an empty string: `''` was becoming `''''`
- Cases where the default value is a quoted string: `'something'` was becoming `''something''`
- Escaping single quotes in the column description: `A monkey's uncle` was becoming `'A monkey's uncle'`, rather than `'A monkey\'s uncle'`
